### PR TITLE
[Feat] Do not spoof a broken elytra

### DIFF
--- a/common/src/main/java/com/deathmotion/antihealthindicator/data/Settings.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/data/Settings.java
@@ -78,7 +78,10 @@ public class Settings {
     public static class Items {
         private boolean Enabled = true;
         private boolean StackAmount = true;
+
         private boolean Durability = true;
+        private boolean BrokenElytra = true;
+
         private boolean Enchantments = true;
     }
 }

--- a/common/src/main/java/com/deathmotion/antihealthindicator/managers/ConfigManager.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/managers/ConfigManager.java
@@ -120,6 +120,7 @@ public class ConfigManager<P> {
         settings.getItems().setEnabled(getBoolean(yamlData, "spoof.entity-data.items.enabled", true));
         settings.getItems().setStackAmount(getBoolean(yamlData, "spoof.entity-data.items.stack-amount.enabled", true));
         settings.getItems().setDurability(getBoolean(yamlData, "spoof.entity-data.items.durability.enabled", true));
+        settings.getItems().setBrokenElytra(getBoolean(yamlData, "spoof.entity-data.items.durability.broken-elytra.enabled", true));
         settings.getItems().setEnchantments(getBoolean(yamlData, "spoof.entity-data.items.enchantments.enabled", true));
     }
 

--- a/common/src/main/java/com/deathmotion/antihealthindicator/packetlisteners/spoofers/EntityEquipmentListener.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/packetlisteners/spoofers/EntityEquipmentListener.java
@@ -121,6 +121,7 @@ public class EntityEquipmentListener<P> extends PacketListenerAbstract {
         }
 
         if (settings.getItems().isDurability() && itemStack.isDamageableItem()) {
+            // Prevent a broken elytra from being spoofed
             if (!settings.getItems().isBrokenElytra() || itemStack.getType() != ItemTypes.ELYTRA || itemStack.getDamageValue() < itemStack.getMaxDamage() - 1) {
                 if (useDamageableInterface) {
                     itemStack.setDamageValue(0);

--- a/common/src/main/java/com/deathmotion/antihealthindicator/packetlisteners/spoofers/EntityEquipmentListener.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/packetlisteners/spoofers/EntityEquipmentListener.java
@@ -26,6 +26,7 @@ import com.github.retrooper.packetevents.event.PacketListenerAbstract;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.item.ItemStack;
+import com.github.retrooper.packetevents.protocol.item.type.ItemTypes;
 import com.github.retrooper.packetevents.protocol.item.enchantment.Enchantment;
 import com.github.retrooper.packetevents.protocol.item.enchantment.type.EnchantmentTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -120,12 +121,14 @@ public class EntityEquipmentListener<P> extends PacketListenerAbstract {
         }
 
         if (settings.getItems().isDurability() && itemStack.isDamageableItem()) {
-            if (useDamageableInterface) {
-                itemStack.setDamageValue(0);
-            } else {
-                itemStack.setLegacyData((short) 0);
+            if (!settings.getItems().isBrokenElytra() || itemStack.getType() != ItemTypes.ELYTRA || itemStack.getDamageValue() < itemStack.getMaxDamage() - 1) {
+                if (useDamageableInterface) {
+                    itemStack.setDamageValue(0);
+                } else {
+                    itemStack.setLegacyData((short) 0);
+                }
+                equipment.setItem(itemStack);
             }
-            equipment.setItem(itemStack);
         }
 
         if (settings.getItems().isEnchantments() && itemStack.isEnchanted(clientVersion)) {

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -119,6 +119,10 @@ spoof:
       durability:
         enabled: true
 
+        # If enabled, elytra durability spoofing will be disabled when the elytra's durability is 1 or less.
+        broken-elytra:
+          enabled: true
+
       # If enabled, hides the enchantments of other players items (e.g., tools, armor).
       # For example, if a player holds a sword with sharpness 5, it won't show the sharpness enchantment.
       # But rather Luck of the Sea I, which is not true, but we need to apply at least one enchantment


### PR DESCRIPTION
**Changes:**

*   Added a new configuration option `broken-elytra` under the `durability` section in the configuration file.
*   When enabled, this option makes other players' elytra appear broken when their durability is 1 or less.

![1](https://github.com/user-attachments/assets/4f4bc415-7704-429f-874d-8377e63af3d7)