### PR TITLE
Fix: Resolve Build Failures by Updating JVM Toolchain from 8 to 21

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 kotlin {
     compilerOptions {
-        jvmToolchain(8)
+        jvmToolchain(21)
     }
 }
 


### PR DESCRIPTION
This PR updates the JVM toolchain from 8 to 21. Builds were failing due to the toolchain being set to 8. Changing it to 21 resolves the build issues.