### PR TITLE
Hide dropped item names

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,6 +13,11 @@ dependencies {
     compileOnlyApi(libs.lombok)
     compileOnly(libs.guava)
     annotationProcessor(libs.lombok)
+    testImplementation(platform("org.junit:junit-bom:5.14.4"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation(libs.bundles.adventure)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.packetevents.api)
 }
 
 // So that SNAPSHOT is always the latest SNAPSHOT
@@ -23,6 +28,10 @@ configurations.all {
 tasks {
     withType<JavaCompile> {
         dependsOn(generateVersionsFile)
+    }
+
+    test {
+        useJUnitPlatform()
     }
 
     generateVersionsFile {

--- a/common/src/main/java/com/deathmotion/antihealthindicator/cache/trackers/EntityTracker.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/cache/trackers/EntityTracker.java
@@ -88,7 +88,7 @@ public class EntityTracker {
 
     private void handleSpawnEntity(WrapperPlayServerSpawnEntity packet, Settings settings) {
         EntityType entityType = packet.getEntityType();
-        if (!EntityTypes.isTypeInstanceOf(entityType, EntityTypes.LIVINGENTITY)) return;
+        if (!EntityTypes.isTypeInstanceOf(entityType, EntityTypes.LIVINGENTITY) && entityType != EntityTypes.ITEM) return;
         if (settings.getEntityData().isPlayersOnly() && !EntityTypes.isTypeInstanceOf(entityType, EntityTypes.PLAYER))
             return;
 

--- a/common/src/main/java/com/deathmotion/antihealthindicator/managers/ConfigManager.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/managers/ConfigManager.java
@@ -128,6 +128,7 @@ public class ConfigManager<P> {
         settings.getItems().setStackAmount(getValue(yaml, "spoof.entity-data.items.stack-amount.enabled", Boolean.class, true));
         settings.getItems().setDurability(getValue(yaml, "spoof.entity-data.items.durability.enabled", Boolean.class, true));
         settings.getItems().setEnchantments(getValue(yaml, "spoof.entity-data.items.enchantments.enabled", Boolean.class, true));
+        settings.getItems().setNames(getValue(yaml, "spoof.entity-data.items.names.enabled", Boolean.class, true));
     }
 
     private <T> T getValue(Map<String, Object> yamlData, String key, Class<T> type, T defaultValue) {

--- a/common/src/main/java/com/deathmotion/antihealthindicator/models/Settings.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/models/Settings.java
@@ -62,5 +62,6 @@ public class Settings {
         private boolean stackAmount = true;
         private boolean durability = true;
         private boolean enchantments = true;
+        private boolean names = true;
     }
 }

--- a/common/src/main/java/com/deathmotion/antihealthindicator/spoofers/impl/MetadataSpoofer.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/spoofers/impl/MetadataSpoofer.java
@@ -34,6 +34,7 @@ import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
+import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 
 public final class MetadataSpoofer extends Spoofer {
@@ -52,9 +53,10 @@ public final class MetadataSpoofer extends Spoofer {
         ((EntityData<@NotNull T>) data).setValue(spoofValue);
     }
 
-    static void removeNameComponents(PatchableComponentMap components) {
-        components.unset(ComponentTypes.CUSTOM_NAME);
-        components.unset(ComponentTypes.ITEM_NAME);
+    static void blankNameComponents(PatchableComponentMap components) {
+        Component blankName = Component.text(" ");
+        components.set(ComponentTypes.CUSTOM_NAME, blankName);
+        components.set(ComponentTypes.ITEM_NAME, blankName);
     }
 
     @Override
@@ -167,7 +169,7 @@ public final class MetadataSpoofer extends Spoofer {
 
         Object value = entityData.getValue();
         if (value instanceof ItemStack) {
-            removeNameComponents(((ItemStack) value).getComponents());
+            blankNameComponents(((ItemStack) value).getComponents());
         }
     }
 

--- a/common/src/main/java/com/deathmotion/antihealthindicator/spoofers/impl/MetadataSpoofer.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/spoofers/impl/MetadataSpoofer.java
@@ -25,9 +25,12 @@ import com.deathmotion.antihealthindicator.models.Settings;
 import com.deathmotion.antihealthindicator.spoofers.Spoofer;
 import com.deathmotion.antihealthindicator.util.HealthUtil;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.component.ComponentTypes;
+import com.github.retrooper.packetevents.protocol.component.PatchableComponentMap;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
+import com.github.retrooper.packetevents.protocol.item.ItemStack;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
 import com.github.retrooper.packetevents.protocol.player.ClientVersion;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
@@ -47,6 +50,11 @@ public final class MetadataSpoofer extends Spoofer {
     @SuppressWarnings("unchecked")
     private static <T> void setValue(EntityData<?> data, T spoofValue) {
         ((EntityData<@NotNull T>) data).setValue(spoofValue);
+    }
+
+    static void removeNameComponents(PatchableComponentMap components) {
+        components.unset(ComponentTypes.CUSTOM_NAME);
+        components.unset(ComponentTypes.ITEM_NAME);
     }
 
     @Override
@@ -99,6 +107,8 @@ public final class MetadataSpoofer extends Spoofer {
             } else {
                 spoofIronGolemMetadata(entityData, settings);
             }
+        } else if (entityType == EntityTypes.ITEM) {
+            spoofDroppedItemMetadata(entityData, settings);
         } else {
             applyDefaultSpoofing(entityData, settings);
             if (entityType == EntityTypes.PLAYER) {
@@ -149,6 +159,15 @@ public final class MetadataSpoofer extends Spoofer {
         }
         if (entityData.getIndex() == player.metadataIndex.XP && settings.getEntityData().isXp()) {
             setDynamicValue(entityData, 0);
+        }
+    }
+
+    private void spoofDroppedItemMetadata(EntityData<?> entityData, Settings settings) {
+        if (!settings.getItems().isEnabled() || !settings.getItems().isNames()) return;
+
+        Object value = entityData.getValue();
+        if (value instanceof ItemStack) {
+            removeNameComponents(((ItemStack) value).getComponents());
         }
     }
 

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -88,6 +88,9 @@ spoof:
       enchantments:
         enabled: true
 
+      names:
+        enabled: true
+
 debug:
   # If enabled, the plugin will print debug messages to players with the permission "AntiHealthIndicator.Debug".
   enabled: false

--- a/common/src/test/java/com/deathmotion/antihealthindicator/spoofers/impl/MetadataSpooferTest.java
+++ b/common/src/test/java/com/deathmotion/antihealthindicator/spoofers/impl/MetadataSpooferTest.java
@@ -1,0 +1,94 @@
+package com.deathmotion.antihealthindicator.spoofers.impl;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.PacketEventsAPI;
+import com.github.retrooper.packetevents.injector.ChannelInjector;
+import com.github.retrooper.packetevents.manager.player.PlayerManager;
+import com.github.retrooper.packetevents.manager.protocol.ProtocolManager;
+import com.github.retrooper.packetevents.manager.server.ServerManager;
+import com.github.retrooper.packetevents.netty.NettyManager;
+import com.github.retrooper.packetevents.protocol.component.ComponentTypes;
+import com.github.retrooper.packetevents.protocol.component.PatchableComponentMap;
+import com.github.retrooper.packetevents.protocol.component.StaticComponentMap;
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class MetadataSpooferTest {
+
+    static {
+        PacketEvents.setAPI(new TestPacketEventsAPI());
+    }
+
+    @Test
+    void removesDroppedItemNameComponents() {
+        PatchableComponentMap components = new PatchableComponentMap(StaticComponentMap.EMPTY);
+        components.set(ComponentTypes.CUSTOM_NAME, Component.text("Diamond"));
+        components.set(ComponentTypes.ITEM_NAME, Component.text("Rare Diamond"));
+
+        MetadataSpoofer.removeNameComponents(components);
+
+        assertFalse(components.has(ComponentTypes.CUSTOM_NAME));
+        assertFalse(components.has(ComponentTypes.ITEM_NAME));
+    }
+
+    private static final class TestPacketEventsAPI extends PacketEventsAPI<Object> {
+        @Override
+        public boolean isLoaded() {
+            return true;
+        }
+
+        @Override
+        public void init() {
+        }
+
+        @Override
+        public void load() {
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        @Override
+        public void terminate() {
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+
+        @Override
+        public Object getPlugin() {
+            return null;
+        }
+
+        @Override
+        public ServerManager getServerManager() {
+            return null;
+        }
+
+        @Override
+        public ProtocolManager getProtocolManager() {
+            return null;
+        }
+
+        @Override
+        public PlayerManager getPlayerManager() {
+            return null;
+        }
+
+        @Override
+        public NettyManager getNettyManager() {
+            return null;
+        }
+
+        @Override
+        public ChannelInjector getInjector() {
+            return null;
+        }
+    }
+}

--- a/common/src/test/java/com/deathmotion/antihealthindicator/spoofers/impl/MetadataSpooferTest.java
+++ b/common/src/test/java/com/deathmotion/antihealthindicator/spoofers/impl/MetadataSpooferTest.java
@@ -13,7 +13,7 @@ import com.github.retrooper.packetevents.protocol.component.StaticComponentMap;
 import net.kyori.adventure.text.Component;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MetadataSpooferTest {
 
@@ -22,15 +22,15 @@ class MetadataSpooferTest {
     }
 
     @Test
-    void removesDroppedItemNameComponents() {
+    void blanksDroppedItemNameComponents() {
         PatchableComponentMap components = new PatchableComponentMap(StaticComponentMap.EMPTY);
         components.set(ComponentTypes.CUSTOM_NAME, Component.text("Diamond"));
         components.set(ComponentTypes.ITEM_NAME, Component.text("Rare Diamond"));
 
-        MetadataSpoofer.removeNameComponents(components);
+        MetadataSpoofer.blankNameComponents(components);
 
-        assertFalse(components.has(ComponentTypes.CUSTOM_NAME));
-        assertFalse(components.has(ComponentTypes.ITEM_NAME));
+        assertEquals(Component.text(" "), components.get(ComponentTypes.CUSTOM_NAME));
+        assertEquals(Component.text(" "), components.get(ComponentTypes.ITEM_NAME));
     }
 
     private static final class TestPacketEventsAPI extends PacketEventsAPI<Object> {


### PR DESCRIPTION
Fixes #26.

Removes custom_name and item_name components from dropped item metadata before clients receive it.

Tested:
- .\gradlew.bat :common:build --console=plain